### PR TITLE
Blanket stomp synchronous warnings

### DIFF
--- a/WindowsGSM/WindowsGSM.csproj
+++ b/WindowsGSM/WindowsGSM.csproj
@@ -44,8 +44,9 @@
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>0</WarningLevel>
+    <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <NoWarn>1998;</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -60,6 +61,7 @@
     <DocumentationFile>
     </DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
+    <NoWarn>1998;</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Images\WindowsGSM.ico</ApplicationIcon>


### PR DESCRIPTION
There's no immediate downside to the problematic async methods running synchronously, so just completely ignore all of them