### PR TITLE
Plugin Tab: Only show plugin name.

### DIFF
--- a/WindowsGSM/MainWindow.xaml.cs
+++ b/WindowsGSM/MainWindow.xaml.cs
@@ -526,7 +526,7 @@ namespace WindowsGSM
                     var label = new Label { Content = $"v{plugin.Plugin.version}", Padding = new Thickness(0) };
                     DockPanel.SetDock(label, Dock.Right);
                     dockPanel.Children.Add(label);
-                    label = new Label { Content = plugin.Plugin.name, Padding = new Thickness(0), FontSize = 14, FontWeight = FontWeights.Bold };
+                    label = new Label { Content = plugin.Plugin.name.Split('.')[1], Padding = new Thickness(0), FontSize = 14, FontWeight = FontWeights.Bold };
                     DockPanel.SetDock(label, Dock.Left);
                     dockPanel.Children.Add(label);
                     dockPanelBase.Children.Add(dockPanel);


### PR DESCRIPTION
Well I do think it looks a bit prettier like this, but up to you ;)
![pluginnames](https://user-images.githubusercontent.com/855150/91671196-c6824e80-eb24-11ea-95b3-561313b3c44a.png)
