### PR TITLE
Added Github Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  Build:
+    runs-on: windows-2019
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup MSBuild.exe
+      uses: microsoft/setup-msbuild@v1
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+    - name: Restore packages
+      run: msbuild WindowsGSM.sln /t:restore
+    - name: Build with MSBuild
+      run: msbuild WindowsGSM.sln


### PR DESCRIPTION
I saw that there is an AppVeyor setup for this project, but the configuration and the results aren't public (at least, not that I'm able to find).

Adding Github Actions CI will add compilation checks into pushes and PRs. Right now, the only integration I see on PRs is Codacy.

Example of a passing job; https://github.com/scowalt/WindowsGSM/actions/runs/395211205