### PR TITLE
Added public modifier to SteamCMD class for access it from plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ Effortlessly remote control your game servers with Discord!
 ### Plugins
 Allow support more game servers by installing plugins!
 ##### Some available plugins (Made by [BattlefieldDuck](https://github.com/BattlefieldDuck)):
-1. [WindowsGSM.ARMA3](https://github.com/BattlefieldDuck/WindowsGSM.ARMA3)
-1. [WindowsGSM.PaperMC](https://github.com/BattlefieldDuck/WindowsGSM.PaperMC)
+1. [WindowsGSM.ARMA2](https://github.com/DevVault/WindowsGSM.ARMA2)
+2. [WindowsGSM.ARMA3](https://github.com/BattlefieldDuck/WindowsGSM.ARMA3)
+3. [WindowsGSM.PaperMC](https://github.com/BattlefieldDuck/WindowsGSM.PaperMC)
 
 ![Screenshot Plugins](https://windowsgsm.com/assets/images/WindowsGSM-Plugins-v1.21.0.png)
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ WindowsGSM is a powerful tool to manage game servers. Equipped with a GUI for se
 
 |               | 🎮 Game Server  | Plugin supported | Query |
 | ------------- | --------------- | --------- | ----- |
+| ![logo](https://github.com/1stian/imgrepo/blob/master/WindowsGSMrepo/arma3.png?raw=true)   | Arma2 & Arma2: OA   |✅|      |
 | ![logo](https://github.com/1stian/imgrepo/blob/master/WindowsGSMrepo/arma3.png?raw=true)   | Arma3   |✅|      |
 | ![logo](https://github.com/1stian/imgrepo/blob/master/WindowsGSMrepo/papermc.png?raw=true)   | PaperMC   |✅| A2S     |
 | ![logo](https://github.com/1stian/imgrepo/blob/master/WindowsGSMrepo/waterfall.png?raw=true)   | PaperMC: Waterfall   |✅| A2S     |

--- a/WindowsGSM/Installer/SteamCMD.cs
+++ b/WindowsGSM/Installer/SteamCMD.cs
@@ -14,7 +14,7 @@ namespace WindowsGSM.Installer
     /// <summary>
     /// This script is very old, so it doesn't written in the best practice, but at least it works
     /// </summary>
-    class SteamCMD
+    public class SteamCMD
     {
         private static readonly string _exeFile = "steamcmd.exe";
         private static readonly string _installPath = ServerPath.GetBin("steamcmd");


### PR DESCRIPTION
Hello, I recently started developing plugins for WindowsGSM, I needed direct access to the SteamCMD installer, and I saw a bunch of errors while using it, although the ARKSE server config doesn't throw them. So, I noticed that the SteamCMD class is public only for WindowsGSM solution, not plugins. I suggest adding a **public** modifier to this class for plugin development :)
Sorry for my bad english :)