### PR TITLE
Add -nocrashdialog for Source games

### DIFF
--- a/WindowsGSM/GameServer/CSGO.cs
+++ b/WindowsGSM/GameServer/CSGO.cs
@@ -4,7 +4,7 @@
     {
         public const string FullName = "Counter-Strike: Global Offensive Dedicated Server";
         public override string Defaultmap { get { return "de_dust2"; } }
-        public override string Additional { get { return "-tickrate 64 -usercon +game_type 0 +game_mode 0 +mapgroup mg_active"; } }
+        public override string Additional { get { return "-tickrate 64 -usercon +game_type 0 +game_mode 0 +mapgroup mg_active -nocrashdialog"; } }
         public override string Game { get { return "csgo"; } }
         public override string AppId { get { return "740"; } }
 

--- a/WindowsGSM/GameServer/CSS.cs
+++ b/WindowsGSM/GameServer/CSS.cs
@@ -4,7 +4,7 @@
     {
         public const string FullName = "Counter-Strike: Source Dedicated Server";
         public override string Defaultmap { get { return "de_dust2"; } }
-        public override string Additional { get { return "-tickrate 64"; } }
+        public override string Additional { get { return "-tickrate 64 -nocrashdialog"; } }
         public override string Game { get { return "cstrike"; } }
         public override string AppId { get { return "232330"; } }
 

--- a/WindowsGSM/GameServer/DODS.cs
+++ b/WindowsGSM/GameServer/DODS.cs
@@ -4,6 +4,7 @@
     {
         public const string FullName = "Day of Defeat: Source Dedicated Server";
         public override string Defaultmap { get { return "dod_anzio"; } }
+        public override string Additional { get { return "-nocrashdialog"; } }
         public override string Game { get { return "dod"; } }
         public override string AppId { get { return "232290"; } }
 

--- a/WindowsGSM/GameServer/GMOD.cs
+++ b/WindowsGSM/GameServer/GMOD.cs
@@ -4,7 +4,7 @@
     {
         public const string FullName = "Garry's Mod Dedicated Server";
         public override string Defaultmap { get { return "gm_construct"; } }
-        public override string Additional { get { return "-tickrate 66 +gamemode sandbox +host_workshop_collection"; } }
+        public override string Additional { get { return "-tickrate 66 +gamemode sandbox +host_workshop_collection -nocrashdialog"; } }
         public override string Game { get { return "garrysmod"; } }
         public override string AppId { get { return "4020"; } }
 

--- a/WindowsGSM/GameServer/HL2DM.cs
+++ b/WindowsGSM/GameServer/HL2DM.cs
@@ -4,7 +4,7 @@
     {
         public const string FullName = "Half-Life 2: Deathmatch Dedicated Server";
         public override string Defaultmap { get { return "dm_runoff"; } }
-        public override string Additional { get { return "+mp_teamplay 1"; } }
+        public override string Additional { get { return "+mp_teamplay 1 -nocrashdialog"; } }
         public override string Game { get { return "hl2mp"; } }
         public override string AppId { get { return "232370"; } }
 

--- a/WindowsGSM/GameServer/L4D2.cs
+++ b/WindowsGSM/GameServer/L4D2.cs
@@ -4,6 +4,7 @@
     {
         public const string FullName = "Left 4 Dead 2 Dedicated Server";
         public override string Defaultmap { get { return "c1m1_hotel"; } }
+        public override string Additional { get { return "-nocrashdialog"; } }
         public override string Game { get { return "left4dead2"; } }
         public override string AppId { get { return "222860"; } }
 

--- a/WindowsGSM/GameServer/NMRIH.cs
+++ b/WindowsGSM/GameServer/NMRIH.cs
@@ -4,6 +4,7 @@
     {
         public const string FullName = "No More Room in Hell Dedicated Server";
         public override string Defaultmap { get { return "nmo_broadway"; } }
+        public override string Additional { get { return "-nocrashdialog"; } }
         public override string Game { get { return "nmrih"; } }
         public override string AppId { get { return "317670"; } }
 

--- a/WindowsGSM/GameServer/TF2.cs
+++ b/WindowsGSM/GameServer/TF2.cs
@@ -4,6 +4,7 @@
     {
         public const string FullName = "Team Fortress 2 Dedicated Server";
         public override string Defaultmap { get { return "cp_badlands"; } }
+        public override string Additional { get { return "-nocrashdialog"; } }
         public override string Game { get { return "tf"; } }
         public override string AppId { get { return "232250"; } }
 

--- a/WindowsGSM/GameServer/ZPS.cs
+++ b/WindowsGSM/GameServer/ZPS.cs
@@ -4,6 +4,7 @@
     {
         public const string FullName = "Zombie Panic Source Dedicated Server";
         public override string Defaultmap { get { return "zps_cinema"; } }
+        public override string Additional { get { return "-nocrashdialog"; } }
         public override string Game { get { return "zps"; } }
         public override string AppId { get { return "17505"; } }
 


### PR DESCRIPTION
This is just a small quality of life change I feel would add to the QOL of WGSM.

Sometimes when a source server would crash on Windows, it would load a dialog box that requires user intervention before the server is Auto restarted by WGSM

As WGSM is targeted towards newer people who may not be at the server a lot of the time, this might be a nice addition.

https://developer.valvesoftware.com/wiki/Command_Line_Options