### PR TITLE
Fixed multiple plugin icon not valid and used icon of last plugin in list

### DIFF
--- a/WindowsGSM/MainWindow.xaml.cs
+++ b/WindowsGSM/MainWindow.xaml.cs
@@ -701,13 +701,17 @@ namespace WindowsGSM
                     {
                         PluginsList.ForEach(delegate (PluginMetadata plugin)
                         {
-                            if (plugin.IsLoaded)
+                            if (plugin.FullName == serverConfig.ServerGame && plugin.IsLoaded)
                             {
                                 icon = plugin.GameImage == PluginManagement.DefaultPluginImage
                                     ? plugin.GameImage.Replace("pack://application:,,,", "/WindowsGSM;component")
                                     : plugin.GameImage;
                             }
                         });
+                    }
+                    if (icon == null)
+                    {
+                        icon = PluginManagement.DefaultPluginImage.Replace("pack://application:,,,", "/WindowsGSM;component");
                     }
 
                     string serverId = i.ToString();

--- a/WindowsGSM/Properties/AssemblyInfo.cs
+++ b/WindowsGSM/Properties/AssemblyInfo.cs
@@ -51,7 +51,7 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.23.0.0")]
-[assembly: AssemblyFileVersion("1.23.0.0")]
+[assembly: AssemblyVersion("1.23.1.0")]
+[assembly: AssemblyFileVersion("1.23.1.0")]
 [assembly: NeutralResourcesLanguage("en")]
 


### PR DESCRIPTION
Hi, i'am fixed bug in server list. If you install multiple server plugins icon for that servers will be equals of last added plugin instead of corresponding server plugin. See pictures for reference:

BEFORE FIX:
![BEFORE](https://user-images.githubusercontent.com/19855136/177611497-7f2fc607-9257-4c1e-bc50-3a078eeb025c.PNG)


AFTER FIX:
![AFTER](https://user-images.githubusercontent.com/19855136/177611523-75a057f0-ad23-41c7-ae6a-105a64693e09.PNG)
