### PR TITLE
Source.cs: Make StartPath string virtual

### DIFF
--- a/WindowsGSM/GameServer/Engine/Source.cs
+++ b/WindowsGSM/GameServer/Engine/Source.cs
@@ -26,7 +26,7 @@ namespace WindowsGSM.GameServer.Engine
         public string Error;
         public string Notice;
 
-        public string StartPath = "srcds.exe";
+        public virtual string StartPath = "srcds.exe";
         public bool AllowsEmbedConsole = true;
         public int PortIncrements = 1;
         public dynamic QueryMethod = new Query.A2S();


### PR DESCRIPTION
This is mainly for a plugin to support Dystopia Dedicated Server, as its `srcds.exe` is found at `bin/win32/srcds.exe` instead of the usual `srcds.exe`. 
**Why do this for a plugin?** SteamCMD will download all the server files, but WindowsGSM will throw an error with code 0, because `IsInstallValid()` (lines 161-164) checks the `StartPath` for `srcds.exe` and finds nothing. Install fails for no other reason, and the server cannot at all be managed through WGSM.
Being able to override `StartPath` should remove this roadblock.