### PR TITLE
Update built-in game plugins

### DIFF
--- a/WindowsGSM/GameServer/CE.cs
+++ b/WindowsGSM/GameServer/CE.cs
@@ -12,7 +12,7 @@ namespace WindowsGSM.GameServer
         public string Notice;
 
         public const string FullName = "Conan Exiles Dedicated Server";
-        public string StartPath = @"ConanSandbox\Binaries\Win64\ConanSandboxServer-Win64-Test.exe";
+        public string StartPath = @"ConanSandbox\Binaries\Win64\ConanSandboxServer-Win64-Shipping.exe";
         public bool AllowsEmbedConsole = true;
         public int PortIncrements = 2;
         public dynamic QueryMethod = new Query.A2S();

--- a/WindowsGSM/GameServer/VTS.cs
+++ b/WindowsGSM/GameServer/VTS.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -106,30 +106,30 @@ namespace WindowsGSM.GameServer
         {
             string version = await GetRemoteBuild();
             if (version == null) { return null; }
-            string tarName = $"vs_server_{version}.tar.gz";
-            string address = $"https://cdn.vintagestory.at/gamefiles/stable/{tarName}";
-            string tarPath = ServerPath.GetServersServerFiles(_serverData.ServerID, tarName);
+            string zipName = $"vs_server_win-x64_{version}.zip";
+            string address = $"https://cdn.vintagestory.at/gamefiles/stable/{zipName}";
+            string zipPath = ServerPath.GetServersServerFiles(_serverData.ServerID, zipName);
 
-            // Download vs_server_{version}.tar.gz from https://cdn.vintagestory.at/gamefiles/stable/
+            // Download vs_server_win-x64_{version}.zip from https://cdn.vintagestory.at/gamefiles/stable/
             using (WebClient webClient = new WebClient())
             {
-                try { await webClient.DownloadFileTaskAsync(address, tarPath); } 
+                try { await webClient.DownloadFileTaskAsync(address, zipPath); } 
                 catch
                 {
-                    Error = $"Fail to download {tarName}";
+                    Error = $"Fail to download {zipName}";
                     return null;
                 }
             }
 
-            // Extract vs_server_{version}.tar.gz
-            if (!await FileManagement.ExtractTarGZ(tarPath, Directory.GetParent(tarPath).FullName))
+            // Extract vs_server_win-x64_{version}.zip
+            if (!await FileManagement.ExtractZip(zipPath, Directory.GetParent(zipPath).FullName))
             {
-                Error = $"Fail to extract {tarName}";
+                Error = $"Fail to extract {zipName}";
                 return null;
             }
 
-            // Delete vs_server_{version}.tar.gz, leave it if fail to delete
-            await FileManagement.DeleteAsync(tarPath);
+            // Delete vs_server_win-x64_{version}.zip, leave it if fail to delete
+            await FileManagement.DeleteAsync(zipPath);
 
             return null;
         }


### PR DESCRIPTION
- For Vintage Story, the file changed from .tar.gz to .zip and they added _win-x64_ to the filename to match the Linux filename. Updated filename and switched to zip extract instead of tar.
- For Conan Exiles, the executable was renamed from -Win64-Test.exe to -Win64-Shipping.exe



Tested inside Visual Studio and was able to successfully download, install, and run the servers.

![Screenshot of WGSM running Vintage Story server](https://github.com/WindowsGSM/WindowsGSM/assets/1958728/974224fd-45a1-42dc-aaf8-f19086924f84)

![Screenshot of WGSM running Conan Exiles server](https://github.com/WindowsGSM/WindowsGSM/assets/1958728/b1fdc8f5-8ac1-46c2-b602-3ee862c3eddf)

